### PR TITLE
Infosivut ehdotuksia

### DIFF
--- a/data/opinto-oikeus.md
+++ b/data/opinto-oikeus.md
@@ -6,6 +6,13 @@ information_page: true
 banner: false
 ---
 
+### Olet oikeutettu hakemaan opiskelupaikkaa jos
+* Olet korkeakoulukelpoinen
+* Osallistut korkeakoulujen yhteishakuun
+* Suoritat ohjelmoinnin moocin aikataulutetun version
+* Saat jokaisesta osasta vähintään 90% pisteistä
+* Osallistut kurssin päätteeksi järjestettävään näyttökokeeseen
+
 Kevään 2020 aikataulutettu Ohjelmoinnin MOOC antaa mahdollisuuden päästä opiskelemaan Helsingin yliopiston matemaattis-luonnontieteellisen tiedekunnan tietojenkäsittelytieteen kandiohjelmaan. Ohjelmoinnin MOOC -kurssin perusteella haetaan opinto-oikeutta korkeakoulujen yhteishaun osana olevassa päähaussa.
 
 Yhteishaun hakuaika on 18.3.-1.4.2020. Hakuaika päättyy klo 15.00. Ohjelmoinnin MOOCin kautta hakiessasi Sinun tulee täyttää päähaun hakulomake, jossa asetat Helsingin yliopiston tietojenkäsittelytieteen ohjelman haluamallesi prioriteetille. Löydät lisätietoja sähköisestä yhteishausta korkeakouluihin [Opintopolku.fi](https://opintopolku.fi/) -portaalista.

--- a/data/opinto-oikeus.md
+++ b/data/opinto-oikeus.md
@@ -13,7 +13,7 @@ banner: false
 * Saat jokaisesta osasta vähintään 90% pisteistä
 * Osallistut kurssin päätteeksi järjestettävään näyttökokeeseen
 
-Kevään 2020 aikataulutettu Ohjelmoinnin MOOC antaa mahdollisuuden päästä opiskelemaan Helsingin yliopiston matemaattis-luonnontieteellisen tiedekunnan tietojenkäsittelytieteen kandiohjelmaan. Ohjelmoinnin MOOC -kurssin perusteella haetaan opinto-oikeutta korkeakoulujen yhteishaun osana olevassa päähaussa.
+Kevään 2020 aikataulutettu Ohjelmoinnin MOOC antaa mahdollisuuden päästä opiskelemaan Helsingin yliopiston matemaattis-luonnontieteellisen tiedekunnan tietojenkäsittelytieteen kandiohjelmaan. Ohjelmoinnin MOOC koostuu kursseista ohjelmoinnin perusteet (5op) ja ohjelmoinnin jatkokurssi (5op). Ohjelmoinnin MOOC -kurssin perusteella haetaan opinto-oikeutta korkeakoulujen yhteishaun osana olevassa päähaussa.
 
 Yhteishaun hakuaika on 18.3.-1.4.2020. Hakuaika päättyy klo 15.00. Ohjelmoinnin MOOCin kautta hakiessasi Sinun tulee täyttää päähaun hakulomake, jossa asetat Helsingin yliopiston tietojenkäsittelytieteen ohjelman haluamallesi prioriteetille. Löydät lisätietoja sähköisestä yhteishausta korkeakouluihin [Opintopolku.fi](https://opintopolku.fi/) -portaalista.
 

--- a/data/opinto-oikeus.md
+++ b/data/opinto-oikeus.md
@@ -16,7 +16,7 @@ Saat kutsun näyttökokeeseen tekemällä aikataulutetun kurssin jokaisesta osas
 
 Ohjelmoinnin MOOCin kautta valitaan 50 opiskelijaa. Voit hakea yhteishaussa korkeakoulupaikkaa myös normaalin valintakokeen kautta sekä ylioppilaskirjoitusten tulosten perusteella. Ohjelmoinnin MOOC -kurssi toimii myös ilmaisena valmennuskurssina yhteishaun valintakokeeseen, jos et MOOC-väylän kautta paikkaa saa.
 
-Yhteishaussa hakemisen edellytyksenä on korkeakoulukelpoisuus ja hakiessasi kevään 2020 haussa oletuksena on, että voit aloittaa opinnot syksyllä 2020. Tämä valintaväylä poistuu vuonna 2021.
+Yhteishaussa hakemisen edellytyksenä on [korkeakoulukelpoisuus](https://www.helsinki.fi/fi/opiskelijaksi/yhteishaku/hakemuksen-liitteet-paahaussa#section-26498) ja hakiessasi kevään 2020 haussa oletuksena on, että voit aloittaa opinnot syksyllä 2020. Tämä valintaväylä poistuu vuonna 2021.
 
 Mikäli olet valmistumassa vasta keväällä 2021, voit hakea opiskelupaikkaa kevään 2020 Ohjelmoinnin MOOC -kurssilla vuotta 2021 varten. Huomaathan että tällöinkin sinun tulee osallistua vuoden 2020 näyttökokeeseen kun olet tehnyt vuoden 2020 version kurssista.
 

--- a/data/opinto-oikeus.md
+++ b/data/opinto-oikeus.md
@@ -7,10 +7,11 @@ banner: false
 ---
 
 ### Olet oikeutettu hakemaan opiskelupaikkaa jos
+
 * Olet korkeakoulukelpoinen
 * Osallistut korkeakoulujen yhteishakuun
 * Suoritat ohjelmoinnin moocin aikataulutetun version
-* Saat jokaisesta osasta vähintään 90% pisteistä
+* Saat jokaisesta osasta vähintään 90% ohjelmointitehtävien pisteistä
 * Osallistut kurssin päätteeksi järjestettävään näyttökokeeseen
 
 Kevään 2020 aikataulutettu Ohjelmoinnin MOOC antaa mahdollisuuden päästä opiskelemaan Helsingin yliopiston matemaattis-luonnontieteellisen tiedekunnan tietojenkäsittelytieteen kandiohjelmaan. Ohjelmoinnin MOOC koostuu kursseista ohjelmoinnin perusteet (5op) ja ohjelmoinnin jatkokurssi (5op). Ohjelmoinnin MOOC -kurssin perusteella haetaan opinto-oikeutta korkeakoulujen yhteishaun osana olevassa päähaussa.

--- a/data/tukivaylat.md
+++ b/data/tukivaylat.md
@@ -21,7 +21,7 @@ Jos kysyt kanavalta apua ohjelmointitehtävään, voit liittää kysymykseesi my
 
 Kurssilla on mahdollisuus saada hyvää ohjelmointiseuraa sekä saada apua tehtäviin, ohjelmointiin ja teknisiin ongelmiin tulemalla kurssin pajaan! Paja sijaitsee Helsingin yliopiston kumpulan kampuksella olevassa Exactum-rakennuksessa. Kaikki ovat tervetulleita pajaan!
 
-Katso Exactum-rakennuksen tarkempi sijainti seuraavasta linkistä: https://www.google.com/maps?hl=en&q=Exactum,+Kumpula+Campus,+Pietari+Kalmin+katu+5,+00560+Helsinki
+Katso Exactum-rakennuksen tarkempi sijainti [täältä](https://www.google.com/maps?hl=en&q=Exactum,+Kumpula+Campus,+Pietari+Kalmin+katu+5,+00560+Helsinki).
 
 Joulukuun 2019 pajaohjausajat (luokka BK107):
 


### PR DESCRIPTION
Sisältää neljä parannusehdotusta.
1. Opinto-oikeus sivulla on nyt linkki HY sivulle missä kerrotaan kuka on korkeakoulukelpoinen
2. Opinto-oikeus sivun alussa on lyhyt checklist siitä mitä opiskelupaikan hakemiseen vaaditaan
3. Opinto-oikeus sivulle lisättiin lause jossa selvennetään mistä kursseista Ohjemloinnin MOOC koostuu
4. Tukiväylät sivulla Exactumin google-map urli muutettiin nätimmäksi linkiksi