### PR TITLE
Update 2-hajautustaulu.md

### DIFF
--- a/data/osa-8/2-hajautustaulu.md
+++ b/data/osa-8/2-hajautustaulu.md
@@ -484,10 +484,10 @@ Kirjasto kirjasto = new Kirjasto();
 kirjasto.lisaaKirja(jarkiJaTunteet);
 kirjasto.lisaaKirja(ylpeysJaEnnakkoluulo);
 
-System.out.println(kirjasto.haeKirja("ylpeys ja ennakkoluulo");
+System.out.println(kirjasto.haeKirja("ylpeys ja ennakkoluulo"));
 System.out.println();
 
-System.out.println(kirjasto.haeKirja("YLPEYS JA ENNAKKOLUULO");
+System.out.println(kirjasto.haeKirja("YLPEYS JA ENNAKKOLUULO"));
 System.out.println();
 
 System.out.println(kirjasto.haeKirja("JÄRKI"));


### PR DESCRIPTION
Lisätty puuttuvat sulkumerkit **Hajautustaulu oliomuuttujana**-kappaleen Kirjasto-luokan käytön esimerkissä:

`System.out.println(kirjasto.haeKirja("ylpeys ja ennakkoluulo"); -> System.out.println(kirjasto.haeKirja("ylpeys ja ennakkoluulo"));
System.out.println(kirjasto.haeKirja("YLPEYS JA ENNAKKOLUULO"); -> System.out.println(kirjasto.haeKirja("YLPEYS JA ENNAKKOLUULO"));`